### PR TITLE
Release v0.1.0 to WAPM

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,40 @@
+name: Releases
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  publish-to-wapm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Install WebAssembly targets
+        run: rustup target add wasm32-unknown-unknown
+      - name: Setup Wasmer
+        uses: wasmerio/setup-wasmer@v1
+      - name: Install cargo-wapm
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-wapm --verbose --debug
+
+      - name: Login to wapm.dev
+        run: |
+          wapm config set registry.url https://registry.wapm.dev
+          wapm login ${{ secrets.WAPM_DEV_TOKEN }}
+      - name: Publish to wapm.dev
+        run: cargo wapm
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to wapm.io
+        run: |
+          wapm config set registry.url https://registry.wapm.io
+          wapm login ${{ secrets.WAPM_PROD_TOKEN }}
+      - name: Publish to wapm.io
+        run: cargo wapm
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/wapm-packages/pulldown-cmark"
 homepage = "https://wasmer.io/"
 license = "MIT OR Apache-2.0"
 rust-version = "1.62.1"
+publish = false
 
 [package.metadata.wapm]
 namespace = "wasmer"


### PR DESCRIPTION
Similar to https://github.com/wasmerio/sha2/pull/10, this adds a `releases.yml` workflow to CI that will automatically publish this package to WAPM.